### PR TITLE
Return object from transform, add map property

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,11 @@ export default createUnplugin<Options | undefined>((options = {}) => {
         svg = optimize(svg, typeof options.optimize === 'object' ? { ...options.optimize, path } : { path }).data
 
       const code = await compileSvg(svg, path, options)
-      return `${code}\nexport default { render };`
+
+      return {
+        code: `${code}\nexport default { render };`,
+        map: { mappings: '' },
+      }
     },
   })
 })


### PR DESCRIPTION
At @ecosia we're using this plugin for a project, and noticed that when we build with Vite and enable source maps, we get this error for every SVG import:

```
(unplugin-svg-vue-component plugin) Sourcemap is likely to be incorrect: a plugin (unplugin-svg-vue-component) was used to transform files, but didn't generate a sourcemap for the transformation. Consult the plugin documentation for help
```

It looks like most similar rollup plugins return an empty source map (which makes sense because we're creating a new bit of code essentially from nothing, rather than transforming an existing piece of code).

I'm hoping returning an empty source map explicitly will suppress this warning.

EDIT: and thank you for making this plugin! It was the only one that fit our specific use case so it's a massive help 🙏 